### PR TITLE
Use double quoted syntax in Collections Example 2

### DIFF
--- a/content/code-examples/refactoring-php/collections-example-2-after.md
+++ b/content/code-examples/refactoring-php/collections-example-2-after.md
@@ -10,7 +10,7 @@ $users = [
 return collect($users)
   ->filter(fn($user) => $user['active'])
   ->sortBy('score')
-  ->transform(fn($user) => $user['name']. ' ('.$user['score'].')')
+  ->transform(fn($user) => "{$user['name']} ({$user['score']})"
   ->values()
   ->toArray();
 ```


### PR DESCRIPTION
Very subtle suggestion: use double quote syntax to allow better readability. 

Note: we could also use `map` instead of `transform` here of course.