### PR TITLE
Replace the static year 2020 with a dynamic year output in the copyright notice in the footer

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -22,7 +22,7 @@
         </div>
         <div class="mt-8 md:mt-0 md:order-1">
             <p class="text-center text-base leading-6 text-gray-400">
-                &copy; 2020 Christoph Rumpel, All rights reserved - <a class="underline" href="{{ route('page.privacy-policy') }}">Privacy Policy</a> - <a class="underline" href="{{ route('page.imprint') }}">Imprint</a>
+                &copy; {{ date('Y') }} Christoph Rumpel, All rights reserved - <a class="underline" href="{{ route('page.privacy-policy') }}">Privacy Policy</a> - <a class="underline" href="{{ route('page.imprint') }}">Imprint</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Use the blade syntax `{{ date('Y') }}` to dynamically output the current year in the footer.